### PR TITLE
Usability Improvements and Multi-Instance Support

### DIFF
--- a/README.nfsroot.md
+++ b/README.nfsroot.md
@@ -15,25 +15,17 @@ Build your rootfs recipe:
 bitbake my-rootfs-image
 ```
 
-Export your rootfs:
-
-```
-NFSROOT=$BUILDDIR/my-nfsroot
-bitbake qemu-helper-native -caddto_recipe_sysroot
-runqemu-extract-sdk $BUILDDIR/tmp/deploy/images/<machine>/<my-rootfs-image-machine>.tar.gz $NFSROOT
-```
-
 Start the update server:
 
 ```
-nfs-export-updater --debug my-rootfs-image $NFSROOT
+nfs-export-updater --debug my-rootfs-image <exportdir>
 ```
 
-This directory can now be exported via a userspace NFS server sharing the pseudo
-database, so user permissions appear correctly on the device-under-test:
+This will
 
-- To start a userspace nfs server: `runqemu-export-rootfs start $NFSROOT`
-- For QEMU you can also use `runqemu qemux86-64 nographic slirp $NFSROOT`
+- extract the rootfs tar archive to the folder `<exportdir>` if this does not exist yet.
+  If the argument is omitted, the default folder name `nfsroot-<image>-${MACHINE}` will be used instead.
+- start a unfsd instance on this folder
 
 To update the nfsroot, it's sufficient to just build the recipe in question.
 To copy files into the nfsroot, use `nfs-cp`, e.g.

--- a/meta/classes/nfsroot.bbclass
+++ b/meta/classes/nfsroot.bbclass
@@ -16,7 +16,7 @@ python nfsroot_eventhandler() {
         # Connect to the server
         client.connect(socket_path)
     except (ConnectionRefusedError, FileNotFoundError):
-        bb.warn('Cannot connect to nfs-export-updater server, skipping update of nfsroot')
+        bb.warn(f'Cannot connect to nfs-export-updater server at {socket_path}, skipping update of nfsroot')
         client.close()
         return
 

--- a/meta/classes/nfsroot.bbclass
+++ b/meta/classes/nfsroot.bbclass
@@ -7,7 +7,7 @@ python nfsroot_eventhandler() {
     import os
 
     # Set the path for the Unix socket
-    socket_path = f"/tmp/nfsup-{os.environ['USER']}.sock"
+    socket_path = f"/tmp/nfsup-{os.environ['USER']}-{d.getVar('MACHINE')}.sock"
 
     # Create the Unix socket client
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/scripts/lib/nfs_export_updater/server.py
+++ b/scripts/lib/nfs_export_updater/server.py
@@ -5,13 +5,6 @@ import logging
 from .pkgindex import update_nfsroot
 from .pkgindex import prepare_native_tools
 
-# Set the path for the Unix domain socket
-socket_path = f"/tmp/nfsup-{os.environ['USER']}.sock"
-
-# Remove the socket file if it already exists
-if os.path.exists(socket_path):
-    os.remove(socket_path)
-
 log = logging.getLogger('nfs-export-updater')
 
 
@@ -58,9 +51,17 @@ class NFSRootUpdateServer():
         print("Client disconnected")
         writer.close()
 
-    async def start_server(self):
+    async def start_server(self, sock_instance):
         log.info("Prepare native tools")
         prepare_native_tools()
+
+        # Set the path for the Unix domain socket
+        socket_path = f"/tmp/nfsup-{os.environ['USER']}-{sock_instance}.sock"
+
+        # Remove the socket file if it already exists
+        if os.path.exists(socket_path):
+            log.info(f"Removing existing socket path {socket_path}")
+            os.remove(socket_path)
 
         server = await asyncio.start_unix_server(self.handle_client, path=socket_path)
         log.info(f"Server is running on {socket_path}")

--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -27,6 +27,36 @@ from nfs_export_updater.server import NFSRootUpdateServer
 logger = logging.getLogger('nfs-export-updater')
 
 
+def create_nfs_exportdir(rootfs, extract_dir):
+    unpack_archive = None
+
+    import bb.tinfoil
+    with bb.tinfoil.Tinfoil() as tinfoil:
+        tinfoil.prepare(quiet=1)
+
+        rd = tinfoil.parse_recipe(rootfs)
+        src_prefix = os.path.join(rd.getVar('DEPLOY_DIR_IMAGE'), rd.getVar('IMAGE_LINK_NAME'))
+        for suffix in ['.tar.bz2', '.tar.gz']:
+            check_path  = f"{src_prefix}{suffix}"
+            logging.debug(f"checking archive path {check_path}")
+            if os.path.exists(check_path):
+                unpack_archive = check_path
+                logging.debug(f"Found existing archive at {check_path}")
+                break
+
+    if not unpack_archive:
+        logger.error(f"Unable to unpack: Could not find rootfs archive. Did you run 'bitbake {rootfs}'?")
+        sys.exit(1)
+
+    cmd = ('bitbake', 'qemu-helper-native', '-caddto_recipe_sysroot')
+    logger.info('Running %s...' % str(cmd))
+    subprocess.check_call(cmd)
+
+    cmd = ('runqemu-extract-sdk', unpack_archive, extract_dir)
+    logger.info('Running %s...' % str(cmd))
+    subprocess.check_call(cmd)
+
+
 def check_free_port(host, port):
     """ Check whether the port is free or not """
     import socket
@@ -78,7 +108,6 @@ NFS export update server for bitbake
 Required steps before starting the server are:
 
 - Add `INHERIT += "nfsroot"` to local.conf or another config file and build a root file system image.
-- Export the root file system via "runqemu-extract-sdk <rootfs-archive> <exportdir>"
 
 You can now modify and update individual packages by running 'bitbake <package>'.
 ''', formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -110,9 +139,9 @@ You can now modify and update individual packages by running 'bitbake <package>'
         args.exportdir = os.path.abspath(args.exportdir)
 
     if not os.path.exists(args.exportdir):
-        logger.error(f"{args.exportdir} does not exist.")
-        logger.error("Did you run runqemu-extract-sdk to create it?")
-        sys.exit(1)
+        logger.info(f"{args.exportdir} does not exist. Creating it..")
+
+        create_nfs_exportdir(args.rootfs, args.exportdir)
 
     setup_nfs_exporter(args.exportdir)
     print("\n") # for visibility of nfs option printout

--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -101,6 +101,13 @@ def setup_nfs_exporter(rootfs):
     subprocess.check_call(cmd)
 
 
+def stop_nfs_exporter(rootfs):
+    logger.info("Shutting down the userspace NFS server...")
+    cmd = ("runqemu-export-rootfs", "stop", rootfs)
+    logger.debug('Running %s' % str(cmd))
+    subprocess.check_call(cmd)
+
+
 def main():
     parser = argparse.ArgumentParser(description='''
 NFS export update server for bitbake
@@ -164,8 +171,13 @@ You can now modify and update individual packages by running 'bitbake <package>'
     logger.info(f"NFS export dir ist at {args.exportdir}")
     logger.info("Starting server..")
 
-    # Start the server
-    asyncio.run(server.start_server(b_machine))
+    try:
+        # Start the server
+        asyncio.run(server.start_server(b_machine))
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        stop_nfs_exporter(args.exportdir)
 
 
 if __name__ == "__main__":

--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -10,6 +10,8 @@ import os
 import sys
 import argparse
 import logging
+import subprocess
+import re
 script_path = os.path.dirname(os.path.realpath(__file__))
 lib_path = script_path + '/lib'
 sys.path = sys.path + [lib_path]
@@ -25,6 +27,50 @@ from nfs_export_updater.server import NFSRootUpdateServer
 logger = logging.getLogger('nfs-export-updater')
 
 
+def check_free_port(host, port):
+    """ Check whether the port is free or not """
+    import socket
+    from contextlib import closing
+
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        if sock.connect_ex((host, port)) == 0:
+            # Port is open, so not free
+            return False
+        else:
+            # Port is not open, so free
+            return True
+
+
+def setup_nfs_exporter(rootfs):
+    nfs_instance = 0
+
+    nfsd_port = 3048 + nfs_instance
+    while not check_free_port('localhost', nfsd_port):
+        nfs_instance += 1
+        nfsd_port += 1
+
+    mountd_port = nfsd_port
+
+    # Export vars for runqemu-export-rootfs
+    export_dict = {
+        'NFS_INSTANCE': nfs_instance,
+        'NFSD_PORT': nfsd_port,
+        'MOUNTD_PORT': mountd_port,
+    }
+    for k, v in export_dict.items():
+        # Use '%s' since they are integers
+        os.putenv(k, '%s' % v)
+
+    cmd = ('bitbake', 'qemu-helper-native', '-caddto_recipe_sysroot')
+    logger.info('Running %s...' % str(cmd))
+    subprocess.check_call(cmd)
+
+    # Start the userspace NFS server
+    cmd = ('runqemu-export-rootfs', 'start', rootfs)
+    logger.info('Running %s...' % str(cmd))
+    subprocess.check_call(cmd)
+
+
 def main():
     parser = argparse.ArgumentParser(description='''
 NFS export update server for bitbake
@@ -33,8 +79,6 @@ Required steps before starting the server are:
 
 - Add `INHERIT += "nfsroot"` to local.conf or another config file and build a root file system image.
 - Export the root file system via "runqemu-extract-sdk <rootfs-archive> <exportdir>"
-- Start a userspace nfs server with "runqemu-export-rootfs start <exportdir>"
-  (for QEMU you can also use "runqemu qemux86-64 nographic slirp <exportdir>").
 
 You can now modify and update individual packages by running 'bitbake <package>'.
 ''', formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -57,6 +101,9 @@ You can now modify and update individual packages by running 'bitbake <package>'
         logger.error("Did you run runqemu-extract-sdk to create it?")
         sys.exit(1)
 
+    setup_nfs_exporter(args.exportdir)
+    print("\n") # for visibility of nfs option printout
+
     # needs to be consistent with runqemu-export-rootfs
     pseudo_localstatedir = os.path.join(
             args.exportdir,
@@ -64,8 +111,7 @@ You can now modify and update individual packages by running 'bitbake <package>'
             os.path.basename(args.exportdir) + '.pseudo_state')
 
     if not os.path.exists(pseudo_localstatedir):
-        logger.error(f"{pseudo_localstatedir} does not exist.")
-        logger.error("Did you run runqemu-export-rootfs to export it?")
+        logger.error(f"{pseudo_localstatedir} does not exist. Maybe runqemu-export-rootfs failed to run?")
         sys.exit(1)
 
     os.environ['PSEUDO_LOCALSTATEDIR'] = pseudo_localstatedir

--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -165,7 +165,7 @@ You can now modify and update individual packages by running 'bitbake <package>'
     logger.info("Starting server..")
 
     # Start the server
-    asyncio.run(server.start_server())
+    asyncio.run(server.start_server(b_machine))
 
 
 if __name__ == "__main__":

--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -83,7 +83,7 @@ Required steps before starting the server are:
 You can now modify and update individual packages by running 'bitbake <package>'.
 ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('rootfs', help='rootfs recipe', action='store')
-    parser.add_argument('exportdir', help='nfs root export directory', action='store')
+    parser.add_argument('exportdir', help='nfs root export directory', action='store', nargs='?', default=None)
     parser.add_argument('-d', '--debug', help='Enable debug output', action='store_true')
 
     args = parser.parse_args()
@@ -92,6 +92,19 @@ You can now modify and update individual packages by running 'bitbake <package>'
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(logging.INFO)
+
+    import bb.tinfoil
+    with bb.tinfoil.Tinfoil() as tinfoil:
+        tinfoil.prepare(quiet=1)
+
+        b_topdir = tinfoil.config_data.getVar('TOPDIR')
+        b_machine = tinfoil.config_data.getVar('MACHINE')
+
+    # figure out default nfsroot directory to use
+    # will be of form ${TOPDIR}/nfsroot-{rootfs}-${MACHINE}'
+    if not args.exportdir:
+        args.exportdir = '%s/nfsroot-%s-%s' % (b_topdir, args.rootfs, b_machine)
+        logging.info(f"Using {args.exportdir} as nfsroot export dir")
 
     if not os.path.isabs(args.exportdir):
         args.exportdir = os.path.abspath(args.exportdir)


### PR DESCRIPTION
Removes the need to run any additional external script (like `runqemu-extract-sdk` or `runqemu-export-rootfs`.

Allows to start multiple instances by figuring out free ports for starting the unfsd and by using machine-specific socket names for interaction.

Also providing an `exportdir` is now optional. It will default to assume and create a `nfsroot-<image>-${MACHINE}` folder.