### PR TITLE
scripts/nfs-export-updater: robust nfs instance detection

### DIFF
--- a/scripts/nfs-export-updater
+++ b/scripts/nfs-export-updater
@@ -57,35 +57,34 @@ def create_nfs_exportdir(rootfs, extract_dir):
     subprocess.check_call(cmd)
 
 
-def check_free_port(host, port):
-    """ Check whether the port is free or not """
+def find_free_nfs_instance():
+    """ Find a port for the NFS server instance """
     import socket
-    from contextlib import closing
 
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        if sock.connect_ex((host, port)) == 0:
-            # Port is open, so not free
-            return False
-        else:
-            # Port is not open, so free
-            return True
+    instance = 0
+    port = 3048
+    tcp_sock = socket.socket()
+    udp_sock = socket.socket(type=socket.SOCK_DGRAM)
 
+    while True:
+        try:
+            tcp_sock.bind(('', port))
+            tcp_sock.close()
+            udp_sock.bind(('', port))
+            udp_sock.close()
+            return port, instance
+        except:
+            instance += 1
+            port += 1
 
 def setup_nfs_exporter(rootfs):
-    nfs_instance = 0
-
-    nfsd_port = 3048 + nfs_instance
-    while not check_free_port('localhost', nfsd_port):
-        nfs_instance += 1
-        nfsd_port += 1
-
-    mountd_port = nfsd_port
+    port, instance = find_free_nfs_instance()
 
     # Export vars for runqemu-export-rootfs
     export_dict = {
-        'NFS_INSTANCE': nfs_instance,
-        'NFSD_PORT': nfsd_port,
-        'MOUNTD_PORT': mountd_port,
+        'NFS_INSTANCE': instance,
+        'NFSD_PORT': port,
+        'MOUNTD_PORT': port,
     }
     for k, v in export_dict.items():
         # Use '%s' since they are integers


### PR DESCRIPTION
This fixes a bug were a socket was already bound but nobody was listening. So the connect would fail, marking the port as free, but the later binding of the same port by unfsd would fail with 'Adress already in use'.

As unfsd by default binds a udp and tcp port to all interfaces extend the check to cover this.